### PR TITLE
Fix execution of eslint fails if command exit code is 0, but stderr has data

### DIFF
--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -250,9 +250,8 @@ stdoutdata, stderrdata = p.communicate(text)
 formattername = vim.eval('b:formatters[s:index]')
 if stderrdata:
     if verbose > 0:
-        print('Formatter {} has errors: {}'.format(formattername, stderrdata))
-    vim.command('return 1')
-elif p.returncode > 0:
+        print('Formatter {} stderr: {}'.format(formattername, stderrdata))
+if p.returncode > 0:
     if verbose > 0:
         print('Formatter {} gives nonzero returncode: {}'.format(formattername, p.returncode))
     vim.command('return 1')
@@ -311,8 +310,8 @@ else:
     formattername = vim.eval('b:formatters[s:index]')
     if stderrdata:
         if verbose > 0:
-            print('Formatter {} has errors: {}'.format(formattername, stderrdata))
-    elif p.returncode > 0:
+            print('Formatter {} stderr: {}'.format(formattername, stderrdata))
+    if p.returncode > 0:
         if verbose > 0:
             print('Formatter {} gives nonzero returncode: {}'.format(formattername, p.returncode))
     elif not stdoutdata:

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -306,7 +306,7 @@ if !exists('g:formatdef_eslint_local')
         let l:eslint_tmp_file = g:BuildESLintTmpFile(l:path, l:ext)
         let content = getline('1', '$')
         call writefile(content, l:eslint_tmp_file)
-        return l:prog." -c ".l:cfg." --fix ".l:eslint_tmp_file." 1> /dev/null; exit_code=$?
+        return l:prog." -c ".l:cfg." --fix ".l:eslint_tmp_file." 1> /dev/null; exit_code=$?;
                     \ cat ".l:eslint_tmp_file."; rm -f ".l:eslint_tmp_file."; exit $exit_code"
     endfunction
     let g:formatdef_eslint_local = "g:BuildESLintLocalCmd()"


### PR DESCRIPTION
Formatter should determine whether the command was executed successfully based on the exit code, not whether stderr is empty. Because eslint sometimes outputs warnning in stderr, but the command was executed successfully. Like the following.
<img width="682" alt="企业微信20220611-214754@2x" src="https://user-images.githubusercontent.com/32935001/173191047-34510d17-00ce-4b4a-b5ad-6ce7388366d0.png">
