### PR TITLE
update default formatter for BUILD files

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -85,10 +85,14 @@ if !exists('g:formatters_cs')
     let g:formatters_cs = ['astyle_cs']
 endif
 
+" Bazel BUILD file
 if !exists('g:formatters_bzl')
     let g:formatters_bzl = ['buildifier']
 endif
 
+if !exists('g:formatdef_buildifier')
+    let g:formatdef_buildifier="'buildifier'"
+endif
 
 " Generic C, C++, Objective-C
 if !exists('g:formatdef_clangformat')


### PR DESCRIPTION
Currently, we don't have a default formatdef_buildifier set correctly for BUILD file formatter.
Add let g:formatdef_buildifier="'buildifier'" to the init.vim works, but it would be nicer if we can add the default to the plugin source, so it can work out-of-box. 

This MR update default formatter for BUILD files.