### PR TITLE
Add formatter for PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ latest`, and then change the default golang formatter by configuring `let g:form
 * `perltidy` for __Perl__.
   It can be installed from CPAN `cpanm Perl::Tidy` . See https://metacpan.org/pod/Perl::Tidy and http://perltidy.sourceforge.net/ for more info.
 
+* `prettier` for __PHP__.
+  It can be installed by running `npm install prettier @prettier/plugin-php` and adding `"plugins": ["@prettier/plugin-php"]` to your [prettier configuration file](https://prettier.io/docs/en/configuration). https://github.com/prettier/plugin-php
+
 * `purty` for __Purescript__
   It can be installed using `npm install purty`. Further instructions available at https://gitlab.com/joneshf/purty
 

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -756,10 +756,10 @@ if !exists('g:formatters_nginx')
 endif
 
 " PHP
-if !exists('g:formatdef_phpfmt')
-    let g:formatdef_phpfmt = '"npx prettier --stdin-filepath ".expand("%:p").(&textwidth ? " --print-width ".&textwidth : "")." --tab-width=".shiftwidth()'
+if !exists('g:formatdef_plugin_php')
+    let g:formatdef_plugin_php = '"npx prettier --stdin-filepath ".expand("%:p").(&textwidth ? " --print-width ".&textwidth : "")." --tab-width=".shiftwidth()'
 endif
 
 if !exists('g:formatters_php')
-    let g:formatters_php = ['phpfmt']
+    let g:formatters_php = ['plugin_php']
 endif

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -754,3 +754,12 @@ endif
 if !exists('g:formatters_nginx')
     let g:formatters_nginx = ['nginxfmt']
 endif
+
+" PHP
+if !exists('g:formatdef_phpfmt')
+    let g:formatdef_phpfmt = '"npx prettier --stdin-filepath ".expand("%:p").(&textwidth ? " --print-width ".&textwidth : "")." --tab-width=".shiftwidth()'
+endif
+
+if !exists('g:formatters_php')
+    let g:formatters_php = ['phpfmt']
+endif


### PR DESCRIPTION
This PR adds a formatter for PHP, which doesn’t have one.

`npx prettier` is used because the current version of Prettier has problems with global install: https://github.com/prettier/prettier/issues/15141#issuecomment-1902669174.